### PR TITLE
Only build master branch w/Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,8 @@ after_success:
 install:
   - "pip install tox"
 script: "tox"
+
+# Only build the master branch. Travis-CI will still build on PR's.
+branches:
+  only:
+    - master


### PR DESCRIPTION
Travis-CI keeps building other branches than master, so this patch
should limit that to master only.